### PR TITLE
Ignore decode errors when parsing files

### DIFF
--- a/SubDomainizer.py
+++ b/SubDomainizer.py
@@ -753,7 +753,7 @@ if __name__ == "__main__":
                 folderData = dict()
                 totalLength = 1
                 file_name = folderName
-                with open(file_name, 'rt') as file:
+                with open(file_name, 'rt', errors='ignore') as file:
                     try:
                         folderData[file_name] = file.read()
                     except UnicodeDecodeError:


### PR DESCRIPTION
**Background for PR:** Suppose you're testing a site that has a CAPTCHA that to some extent blocks tools like SubDomainizer from getting any useful responses. My workaround for this situation so far has been to manually browse the site with an intercepting proxy like ZAP or BurpSuite and manually click myself past the CAPTCHAs. Once I'm happy with my exploration of the site I'll dump all the response data to file and run `python3 SubDomainizer.py -f <dir with files>` on it. That initially failed for me because the response data has binary content that breaks "file.read()" ('t' flag/text). I added `errors='ignore'` to it to resolve that problem.

If you've got a better way or any thoughts or ideas about this I'd love to hear it. Thanks for making this tool!

**Commit comment:**
This change only applies to when using the "-f" argument for parsing
files in a directory. Suppose you have some binary data in your file(s)
you will then end up with decoding errors when reading the file(s).
Ignoring errors lets you move past the binary data and continue
processing the remainder of the file(s).