### PR TITLE
fix: fixed windows prompt colors

### DIFF
--- a/SubDomainizer.py
+++ b/SubDomainizer.py
@@ -34,6 +34,9 @@ import os
 import time
 import warnings
 
+import colorama
+colorama.init()
+
 parse = argparse.ArgumentParser()
 parse.add_argument('-c', '--cookie',
                    help="Cookies which needs to be sent with request. User double quotes if have more than one.")


### PR DESCRIPTION
On windows prompt, the colors doesn't get printed correctly.
<img src="https://user-images.githubusercontent.com/50470310/105636747-81024d00-5e48-11eb-875e-260534266c1d.png" width=800 height=300>

But if we put the colorama scheme, the colors works without problems.
<img src="https://user-images.githubusercontent.com/50470310/105636764-8fe8ff80-5e48-11eb-8e2e-23a596ba68e7.png" width=800 height=300>

Best regards,
oppsec.
