### PR TITLE
Check for existence of content-type header before accessing its value

### DIFF
--- a/SubDomainizer.py
+++ b/SubDomainizer.py
@@ -252,7 +252,7 @@ class JsExtract:
             else:
                 req = requests.get('http://' + url, headers=heads, timeout=(20, 20))
         try:
-            if 'text/html' in req.headers.get('content-type'):
+            if 'text/html' in req.headers.get('content-type', 'None'):
                 html = unquote(req.content.decode('unicode-escape'))
                 soup = BeautifulSoup(html, features='html.parser')
 


### PR DESCRIPTION
`content-type` header is not always returned. Check before attempting to access the header